### PR TITLE
minimal py3.12 fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,8 @@ license = {file = "LICENSE"}
 readme = {file = "README.md", content-type = "text/markdown"}
 description = "PoreAnalyser package based on HOLE and MDAnalysis"
 version = "0.0.11"
-requires-python = ">=3.6,<=3.12"
+requires-python = ">=3.6,<3.13"
 dependencies = [
-#'python<=3.12',
 'numpy >=1.0',
 'MDAnalysis >=2.0, <3.0',
 'matplotlib>=0.1',

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,10 @@ setup(
     url='https://poreanalyser.bioch.ox.ac.uk/',
     author='David Seiferth',
     author_email='david.seiferth@oriel.ox.ac.uk',
-    python_requires='>=3.6,<=3.12',
+    python_requires='>=3.6,<3.13',
     #license='BSD 2-clause',
     packages=['PoreAnalyser'],
     install_requires=[
-        #'python<=3.12',
         'numpy>=1.0',  # 1.22.0
         'MDAnalysis>=2.0,<3.0', #2.0.0
         'matplotlib>=0.1', # 3.5.1 for base , for inline 0.1.3
@@ -37,5 +36,6 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 )


### PR DESCRIPTION
@DSeiferth 

I'm not sure exactly what's going on, but on a fresh Python 3.12 install on my end, it looks like `pip` just gets confused when you attempt to install poreanalyzer as-is.

I found that changing the pin to be <3.13 instead of <=3.12 seems to fix things.